### PR TITLE
grids -= operator fix

### DIFF
--- a/library/vcl/containers/grid/grid_2D/grid_2D.hpp
+++ b/library/vcl/containers/grid/grid_2D/grid_2D.hpp
@@ -508,7 +508,7 @@ template <typename T> grid_2D<T>  operator+(T const& a, grid_2D<T> const& b)
 template <typename T> grid_2D<T>& operator-=(grid_2D<T>& a, grid_2D<T> const& b)
 {
     assert_vcl( is_equal(a.dimension,b.dimension), "Dimension do not agree: a:"+str(a.dimension)+", b:"+str(b.dimension) );
-    a.data += b.data;
+    a.data -= b.data;
 }
 template <typename T> grid_2D<T>& operator-=(grid_2D<T>& a, T const& b)
 {

--- a/library/vcl/containers/grid/grid_3D/grid_3D.hpp
+++ b/library/vcl/containers/grid/grid_3D/grid_3D.hpp
@@ -450,7 +450,7 @@ template <typename T> grid_3D<T>  operator+(T const& a, grid_3D<T> const& b)
 template <typename T> grid_3D<T>& operator-=(grid_3D<T>& a, grid_3D<T> const& b)
 {
     assert_vcl( is_equal(a.dimension,b.dimension), "Dimension do not agree: a:"+str(a.dimension)+", b:"+str(b.dimension) );
-    a.data += b.data;
+    a.data -= b.data;
 }
 template <typename T> grid_3D<T>& operator-=(grid_3D<T>& a, T const& b)
 {


### PR DESCRIPTION
With @PotatoAim101 found 2 similar bugs in grid structure implementation connected with -= operator. Obviously it should subtract and not add value 